### PR TITLE
Transformer fixes

### DIFF
--- a/src/jimm/common/transformer.py
+++ b/src/jimm/common/transformer.py
@@ -1,7 +1,6 @@
-from typing import Optional
 from functools import partial
+from typing import Optional
 
-import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh


### PR DESCRIPTION
This pull request refactors the activation function handling in the `TransformerEncoder` class and removes the `quickgelu` function. It also includes minor cleanup in imports for better organization.

### Refactoring of activation function:

* [`src/jimm/common/transformer.py`](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L84-R80): Replaced the conditional logic for selecting the activation function with `functools.partial` to dynamically configure `nnx.gelu` based on the `use_quick_gelu` parameter. This simplifies the code and removes the need for a custom `quickgelu` implementation.

### Code cleanup:

* [`src/jimm/common/transformer.py`](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L14-L17): Removed the `quickgelu` function, as it is no longer needed following the refactor.
* [`src/jimm/common/transformer.py`](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06R1-L3): Removed the unused `jax` import and added the `functools.partial` import to support the refactored activation function logic.