### PR TITLE
refactor: replace hidden_act string with act_fn callable and tighten test tolerances

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -15,7 +15,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-  rev = "v0.15.17"
+rev = "v0.15.17"
 hooks = [
   { id = "ruff", args = ["--fix"] },
   { id = "ruff", args = ["check", "--select", "I", "--fix"] },

--- a/prek.toml
+++ b/prek.toml
@@ -15,7 +15,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.14.1"
+  rev = "v0.15.17"
 hooks = [
   { id = "ruff", args = ["--fix"] },
   { id = "ruff", args = ["check", "--select", "I", "--fix"] },

--- a/src/jimm/common/transformer.py
+++ b/src/jimm/common/transformer.py
@@ -246,7 +246,7 @@ class TransformerEncoder(nnx.Module):
                 bias_init=nnx.with_partitioning(nnx.initializers.zeros_init(), sharding.layernorm),
             )
 
-        activation_fn = act_fn if act_fn is not None else functools.partial(jax.nn.gelu, approximate=False)
+        activation_fn = self._act_fn
 
         def _lin(in_f: int, out_f: int, k_spec: Any, b_spec: Any) -> nnx.Linear:
             return nnx.Linear(

--- a/src/jimm/common/transformer.py
+++ b/src/jimm/common/transformer.py
@@ -117,12 +117,11 @@ class TransformerEncoder(nnx.Module):
         layernorm_epsilon: float = 1e-5,
         dropout_rate: float = 0.0,
         attn_mask: Float[Array, "seq seq"] | None = None,
-        use_quick_gelu: bool = False,
+        act_fn: Callable | None = None,
         use_gradient_checkpointing: bool = False,
         use_layer_scale: bool = False,
         layer_scale_init: float = 1.0,
         use_gated_mlp: bool = False,
-        hidden_act: str = "gelu",
         key_bias: bool = True,
         attn_bias: bool = True,
         mlp_bias: bool = True,
@@ -142,13 +141,14 @@ class TransformerEncoder(nnx.Module):
             layernorm_epsilon (float, optional): The epsilon used in layernorm calculation. Defaults to 1e-5.
             dropout_rate (float, optional): Dropout rate. Defaults to 0.0.
             attn_mask (Float[Array, "seq seq"] | None, optional): Optional attention mask. Defaults to None.
-            use_quick_gelu (bool, optional): Whether to use quickgelu instead of gelu. Defaults to False.
+            act_fn (Callable | None, optional): MLP activation function. When None, defaults to exact GELU.
+                Pass ``quickgelu`` for CLIP, ``functools.partial(jax.nn.gelu, approximate=True)`` for SigLIP,
+                or ``jax.nn.silu`` for SwiGLU-style models. Defaults to None.
             use_gradient_checkpointing (bool, optional): Whether to checkpoint the attention and MLP sublayers. Defaults to False.
             use_layer_scale (bool, optional): Whether to apply per-channel LayerScale to residuals (DINOv2). Defaults to False.
             layer_scale_init (float, optional): Initial value for LayerScale parameters. Defaults to 1.0.
                 When training from scratch the DINOv2 paper uses much smaller values (e.g. 1e-5 for large models).
             use_gated_mlp (bool, optional): Whether to use gated (SwiGLU-style) MLP. Defaults to False.
-            hidden_act (str, optional): Activation function for (gated) MLP — "gelu" or "silu". Defaults to "gelu".
             key_bias (bool, optional): Whether to include a bias in the key projection. Only applies when attn_bias=True. Defaults to True.
             attn_bias (bool, optional): Whether to include biases in all attention projections (q, k, v, out). Defaults to True.
             mlp_bias (bool, optional): Whether to include biases in MLP linear layers. Defaults to True.
@@ -164,8 +164,6 @@ class TransformerEncoder(nnx.Module):
         """
         if rngs is None:
             rngs = nnx.Rngs(0)
-        if hidden_act not in ("gelu", "silu"):
-            raise ValueError(f"hidden_act must be 'gelu' or 'silu', got {hidden_act!r}")
         self.attn_mask = nnx.Variable(attn_mask) if attn_mask is not None else None
         self.use_gradient_checkpointing = use_gradient_checkpointing
         self.use_layer_scale = use_layer_scale
@@ -173,7 +171,7 @@ class TransformerEncoder(nnx.Module):
         self.num_heads = num_heads
         self.head_dim = hidden_size // num_heads
         self._skip_flax_mask = attention_fn is not None
-        self._act_fn = jax.nn.silu if hidden_act == "silu" else functools.partial(jax.nn.gelu, approximate=False)
+        self._act_fn = act_fn if act_fn is not None else functools.partial(jax.nn.gelu, approximate=False)
         if use_layer_scale:
             ls_init: Float[Array, " hidden_size"] = jnp.full((hidden_size,), layer_scale_init, dtype=param_dtype)
             self.layer_scale1 = nnx.Param(ls_init, out_sharding=sharding.layer_scale)
@@ -248,8 +246,7 @@ class TransformerEncoder(nnx.Module):
                 bias_init=nnx.with_partitioning(nnx.initializers.zeros_init(), sharding.layernorm),
             )
 
-        # nnx.gelu == jax.nn.gelu(approximate=False); explicit here so DINOv2's exact-GELU requirement is clear.
-        activation_fn = quickgelu if use_quick_gelu else functools.partial(jax.nn.gelu, approximate=False)
+        activation_fn = act_fn if act_fn is not None else functools.partial(jax.nn.gelu, approximate=False)
 
         def _lin(in_f: int, out_f: int, k_spec: Any, b_spec: Any) -> nnx.Linear:
             return nnx.Linear(
@@ -435,12 +432,11 @@ class Transformer(nnx.Module):
         layernorm_epsilon: float = 1e-6,
         dropout_rate: float = 0.0,
         attn_mask: Float[Array, "seq seq"] | None = None,
-        use_quick_gelu: bool = False,
+        act_fn: Callable | None = None,
         use_gradient_checkpointing: bool = False,
         use_layer_scale: bool = False,
         layer_scale_init: float = 1.0,
         use_gated_mlp: bool = False,
-        hidden_act: str = "gelu",
         key_bias: bool = True,
         attn_bias: bool = True,
         mlp_bias: bool = True,
@@ -461,13 +457,14 @@ class Transformer(nnx.Module):
             layernorm_epsilon (float, optional): The epsilon used in layernorm calculation. Defaults to 1e-6.
             dropout_rate (float, optional): The dropout rate. Defaults to 0.0.
             attn_mask (Float[Array, "seq seq"] | None, optional): Optional attention mask. Defaults to None.
-            use_quick_gelu (bool, optional): Whether to use quickgelu instead of gelu. Defaults to False.
+            act_fn (Callable | None, optional): MLP activation function. When None, defaults to exact GELU.
+                Pass ``quickgelu`` for CLIP, ``functools.partial(jax.nn.gelu, approximate=True)`` for SigLIP,
+                or ``jax.nn.silu`` for SwiGLU-style models. Defaults to None.
             use_gradient_checkpointing (bool, optional): Whether to use gradient checkpointing. Defaults to False.
             use_layer_scale (bool, optional): Whether to apply per-channel LayerScale to residuals. Defaults to False.
             layer_scale_init (float, optional): Initial value for LayerScale parameters. Defaults to 1.0.
                 When training from scratch the DINOv2 paper uses much smaller values (e.g. 1e-5 for large models).
             use_gated_mlp (bool, optional): Whether to use gated (SwiGLU-style) MLP. Defaults to False.
-            hidden_act (str, optional): Activation for (gated) MLP — "gelu" or "silu". Defaults to "gelu".
             key_bias (bool, optional): Whether to include a bias in the key projection. Only applies when attn_bias=True. Defaults to True.
             attn_bias (bool, optional): Whether to include biases in all attention projections. Defaults to True.
             mlp_bias (bool, optional): Whether to include biases in MLP linear layers. Defaults to True.
@@ -496,12 +493,11 @@ class Transformer(nnx.Module):
                 layernorm_epsilon=layernorm_epsilon,
                 dropout_rate=dropout_rate,
                 attn_mask=attn_mask,
-                use_quick_gelu=use_quick_gelu,
+                act_fn=act_fn,
                 use_gradient_checkpointing=False,
                 use_layer_scale=use_layer_scale,
                 layer_scale_init=layer_scale_init,
                 use_gated_mlp=use_gated_mlp,
-                hidden_act=hidden_act,
                 key_bias=key_bias,
                 attn_bias=attn_bias,
                 mlp_bias=mlp_bias,

--- a/src/jimm/common/vit.py
+++ b/src/jimm/common/vit.py
@@ -2,6 +2,7 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import rnglib
@@ -28,6 +29,7 @@ class MultiHeadAttentionPoolingHead(nnx.Module):
         intermediate_size: int,
         num_heads: int,
         layernorm_epsilon: float = 1e-6,
+        act_fn: Callable | None = None,
         attention_fn: Callable[..., Any] | None = None,
         rngs: rnglib.Rngs | None = None,
         dtype: DTypeLike = jnp.float32,
@@ -41,6 +43,8 @@ class MultiHeadAttentionPoolingHead(nnx.Module):
             intermediate_size (int): The dimension of the intermediate MLP at the end of the MAP head.
             num_heads (int): The number of attention heads.
             layernorm_epsilon (float, optional): The epsilon used in the layernorm. Defaults to 1e-6.
+            act_fn (Callable | None, optional): MLP activation function. When None, defaults to exact GELU.
+                Pass ``functools.partial(jax.nn.gelu, approximate=True)`` for SigLIP. Defaults to None.
             attention_fn (Callable[..., Any] | None, optional): Custom attention function compatible with
                 nnx.MultiHeadAttention's attention_fn interface (e.g. jimm.tokamax_attention or jimm.make_tokamax_attention("mosaic_tpu")).
                 Defaults to None (uses nnx.dot_product_attention).
@@ -98,6 +102,8 @@ class MultiHeadAttentionPoolingHead(nnx.Module):
             ),
         )
 
+        _mlp_act = act_fn if act_fn is not None else nnx.gelu
+
         self.mlp = nnx.Sequential(
             nnx.Linear(
                 hidden_size,
@@ -114,7 +120,7 @@ class MultiHeadAttentionPoolingHead(nnx.Module):
                     sharding.mlp_up_bias,
                 ),
             ),
-            nnx.gelu,
+            _mlp_act,
             nnx.Linear(
                 intermediate_size,
                 hidden_size,
@@ -166,7 +172,7 @@ class VisionTransformerBase(nnx.Module):
         layernorm_epsilon: float = 1e-5,
         pooling_type: str = "CLS",
         dropout_rate: float = 0.0,
-        use_quick_gelu: bool = False,
+        act_fn: Callable | None = None,
         use_pre_norm: bool = False,
         use_patch_bias: bool = True,
         use_gradient_checkpointing: bool = False,
@@ -176,7 +182,6 @@ class VisionTransformerBase(nnx.Module):
         rope_theta: float = 100.0,
         num_register_tokens: int = 0,
         use_gated_mlp: bool = False,
-        hidden_act: str = "gelu",
         key_bias: bool = True,
         attn_bias: bool = True,
         mlp_bias: bool = True,
@@ -203,7 +208,9 @@ class VisionTransformerBase(nnx.Module):
                 patch token embeddings as (batch, n_patches, hidden_size); no CLS token is prepended in this
                 mode. Defaults to "CLS".
             dropout_rate (float, optional): The dropout rate. Defaults to 0.0.
-            use_quick_gelu (bool, optional): Whether to use QuickGELU activation. Defaults to False.
+            act_fn (Callable | None, optional): MLP activation function. When None, defaults to exact GELU.
+                Pass ``quickgelu`` for CLIP, ``functools.partial(jax.nn.gelu, approximate=True)`` for SigLIP,
+                or ``jax.nn.silu`` for SwiGLU-style models. Defaults to None.
             use_pre_norm (bool, optional): Whether to apply a norm after patch+pos embeddings, before the transformer. Defaults to False.
             use_patch_bias (bool, optional): Whether to use bias in the patch embedding convolution. Defaults to True.
             use_gradient_checkpointing (bool, optional): Whether to use gradient checkpointing. Defaults to False.
@@ -216,7 +223,6 @@ class VisionTransformerBase(nnx.Module):
             num_register_tokens (int, optional): Number of learnable register tokens prepended between CLS and
                 patch tokens. Defaults to 0.
             use_gated_mlp (bool, optional): Whether to use gated (SwiGLU-style) MLP. Defaults to False.
-            hidden_act (str, optional): Activation for (gated) MLP — "gelu" or "silu". Defaults to "gelu".
             key_bias (bool, optional): Whether to include a bias in the key projection. Only applies when attn_bias=True. Defaults to True.
             attn_bias (bool, optional): Whether to include biases in all attention projections (q, k, v, out). Defaults to True.
             mlp_bias (bool, optional): Whether to include biases in MLP linear layers. Defaults to True.
@@ -284,6 +290,7 @@ class VisionTransformerBase(nnx.Module):
                 intermediate_size=4 * hidden_size,
                 num_heads=num_heads,
                 layernorm_epsilon=layernorm_epsilon,
+                act_fn=act_fn,
                 attention_fn=attention_fn,
                 dtype=dtype,
                 param_dtype=param_dtype,
@@ -324,12 +331,11 @@ class VisionTransformerBase(nnx.Module):
             num_heads=num_heads,
             layernorm_epsilon=layernorm_epsilon,
             dropout_rate=dropout_rate,
-            use_quick_gelu=use_quick_gelu,
+            act_fn=act_fn,
             use_gradient_checkpointing=use_gradient_checkpointing,
             use_layer_scale=use_layer_scale,
             layer_scale_init=layer_scale_init,
             use_gated_mlp=use_gated_mlp,
-            hidden_act=hidden_act,
             key_bias=key_bias,
             attn_bias=attn_bias,
             mlp_bias=mlp_bias,
@@ -344,7 +350,6 @@ class VisionTransformerBase(nnx.Module):
         self.num_heads = num_heads
         self.mlp_dim = mlp_dim
         self.use_gated_mlp = use_gated_mlp
-        self.hidden_act = hidden_act
         self.layernorm_epsilon = layernorm_epsilon
         self.use_gradient_checkpointing = use_gradient_checkpointing
         self.layers = _transformer.layers

--- a/src/jimm/common/vit.py
+++ b/src/jimm/common/vit.py
@@ -102,7 +102,7 @@ class MultiHeadAttentionPoolingHead(nnx.Module):
             ),
         )
 
-        _mlp_act = act_fn if act_fn is not None else nnx.gelu
+        _mlp_act = act_fn if act_fn is not None else functools.partial(jax.nn.gelu, approximate=False)
 
         self.mlp = nnx.Sequential(
             nnx.Linear(

--- a/src/jimm/models/aimv2/aimv2_model.py
+++ b/src/jimm/models/aimv2/aimv2_model.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import rnglib
@@ -71,7 +72,7 @@ class AIMv2Model(nnx.Module):
             layernorm_epsilon=rms_norm_eps,
             pooling_type="ALL",
             dropout_rate=0.0,
-            use_quick_gelu=False,
+            act_fn=jax.nn.silu,
             use_pre_norm=True,
             pre_norm_before_pos=True,
             use_patch_bias=True,
@@ -80,7 +81,6 @@ class AIMv2Model(nnx.Module):
             use_rope=False,
             num_register_tokens=0,
             use_gated_mlp=True,
-            hidden_act="silu",
             key_bias=False,
             attn_bias=False,
             mlp_bias=False,

--- a/src/jimm/models/clip/clip_model.py
+++ b/src/jimm/models/clip/clip_model.py
@@ -9,7 +9,7 @@ from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, DTypeLike, Float, Int
 
 from jimm.common.sharding import ShardingSpec, named_sharding_like, reshard_like, sharding_of
-from jimm.common.transformer import Transformer
+from jimm.common.transformer import Transformer, quickgelu
 from jimm.common.vit import VisionTransformerBase
 from jimm.models.clip.sharding import CLIPSharding
 
@@ -64,7 +64,7 @@ class CLIPVisionModel(nnx.Module):
             mlp_dim=vision_hidden_size * 4,
             use_pre_norm=True,
             use_patch_bias=False,
-            use_quick_gelu=True,
+            act_fn=quickgelu,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             pooling_type="CLS",
@@ -256,7 +256,8 @@ class CLIPTextModel(nnx.Module):
             num_heads=num_text_heads,
             dropout_rate=0.0,
             attn_mask=attn_mask,
-            use_quick_gelu=True,
+            layernorm_epsilon=1e-5,
+            act_fn=quickgelu,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             rngs=rngs,

--- a/src/jimm/models/dinov2/dinov2_model.py
+++ b/src/jimm/models/dinov2/dinov2_model.py
@@ -72,7 +72,6 @@ class DINOv2Model(nnx.Module):
             mlp_dim=mlp_dim,
             pooling_type="CLS",
             dropout_rate=0.0,
-            use_quick_gelu=False,
             use_pre_norm=False,
             use_patch_bias=True,
             layernorm_epsilon=1e-6,

--- a/src/jimm/models/dinov3/dinov3_model.py
+++ b/src/jimm/models/dinov3/dinov3_model.py
@@ -1,6 +1,8 @@
+import functools
 from collections.abc import Callable
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import rnglib
@@ -10,6 +12,11 @@ from jaxtyping import Array, Float
 from jimm.common.sharding import ShardingSpec
 from jimm.common.vit import VisionTransformerBase
 from jimm.models.dinov3.sharding import DINOv3Sharding
+
+_ACT_FN_MAP: dict[str, Callable] = {
+    "gelu": functools.partial(jax.nn.gelu, approximate=False),
+    "silu": jax.nn.silu,
+}
 
 
 class DINOv3Model(nnx.Module):
@@ -76,8 +83,11 @@ class DINOv3Model(nnx.Module):
             rngs = nnx.Rngs(0)
         if attention_fn is not None:
             raise ValueError("DINOv3 uses a manual RoPE attention path that bypasses nnx.MultiHeadAttention.__call__; attention_fn is not supported. Remove the attention_fn argument.")
+        if hidden_act not in _ACT_FN_MAP:
+            raise ValueError(f"hidden_act must be one of {list(_ACT_FN_MAP)}, got {hidden_act!r}")
         self._original_config = None
         self._layer_scale_init = layer_scale_init
+        self.hidden_act = hidden_act
         self.encoder = VisionTransformerBase(
             img_size=img_size,
             patch_size=patch_size,
@@ -88,7 +98,6 @@ class DINOv3Model(nnx.Module):
             mlp_dim=mlp_dim,
             pooling_type="CLS",
             dropout_rate=0.0,
-            use_quick_gelu=False,
             use_pre_norm=False,
             use_patch_bias=use_patch_bias,
             layernorm_epsilon=layernorm_epsilon,
@@ -98,7 +107,7 @@ class DINOv3Model(nnx.Module):
             rope_theta=rope_theta,
             num_register_tokens=num_register_tokens,
             use_gated_mlp=use_gated_mlp,
-            hidden_act=hidden_act,
+            act_fn=_ACT_FN_MAP[hidden_act],
             key_bias=key_bias,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=None,

--- a/src/jimm/models/dinov3/dinov3_model.py
+++ b/src/jimm/models/dinov3/dinov3_model.py
@@ -18,6 +18,8 @@ _ACT_FN_MAP: dict[str, Callable] = {
     "silu": jax.nn.silu,
 }
 
+_DEFAULT_ACT_FN: Callable = _ACT_FN_MAP["gelu"]
+
 
 class DINOv3Model(nnx.Module):
     """DINOv3 vision transformer feature extractor.
@@ -40,7 +42,7 @@ class DINOv3Model(nnx.Module):
         rope_theta: float = 100.0,
         layer_scale_init: float = 1.0,
         layernorm_epsilon: float = 1e-5,
-        hidden_act: str = "gelu",
+        act_fn: Callable | None = None,
         use_gated_mlp: bool = False,
         use_patch_bias: bool = True,
         key_bias: bool = False,
@@ -65,7 +67,7 @@ class DINOv3Model(nnx.Module):
             rope_theta (float, optional): RoPE base frequency. Defaults to 100.0.
             layer_scale_init (float, optional): Initial value for per-channel LayerScale parameters. Defaults to 1.0.
             layernorm_epsilon (float, optional): LayerNorm epsilon. Defaults to 1e-5.
-            hidden_act (str, optional): MLP activation — "gelu" or "silu". Defaults to "gelu".
+            act_fn (Callable | None, optional): MLP activation function. Defaults to exact GELU.
             use_gated_mlp (bool, optional): Whether to use gated (SwiGLU-style) MLP. Defaults to False.
                 Note: HuggingFace DINOv3 checkpoints typically use True; use from_pretrained or from_config
                 to load the correct architecture automatically rather than relying on this default.
@@ -83,11 +85,10 @@ class DINOv3Model(nnx.Module):
             rngs = nnx.Rngs(0)
         if attention_fn is not None:
             raise ValueError("DINOv3 uses a manual RoPE attention path that bypasses nnx.MultiHeadAttention.__call__; attention_fn is not supported. Remove the attention_fn argument.")
-        if hidden_act not in _ACT_FN_MAP:
-            raise ValueError(f"hidden_act must be one of {list(_ACT_FN_MAP)}, got {hidden_act!r}")
+        _act_fn = act_fn if act_fn is not None else _DEFAULT_ACT_FN
         self._original_config = None
         self._layer_scale_init = layer_scale_init
-        self.hidden_act = hidden_act
+        self._act_fn = _act_fn
         self.encoder = VisionTransformerBase(
             img_size=img_size,
             patch_size=patch_size,
@@ -107,7 +108,7 @@ class DINOv3Model(nnx.Module):
             rope_theta=rope_theta,
             num_register_tokens=num_register_tokens,
             use_gated_mlp=use_gated_mlp,
-            act_fn=_ACT_FN_MAP[hidden_act],
+            act_fn=_act_fn,
             key_bias=key_bias,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=None,
@@ -184,6 +185,8 @@ class DINOv3Model(nnx.Module):
     def _parse_config(cls, config: dict[str, Any]) -> dict[str, Any]:
         hidden_size = config["hidden_size"]
         mlp_dim = config.get("intermediate_size", int(hidden_size * config.get("mlp_ratio", 4)))
+        hidden_act_str = config.get("hidden_act", "gelu")
+        act_fn = _ACT_FN_MAP.get(hidden_act_str, _DEFAULT_ACT_FN)
         return {
             "img_size": config.get("image_size", 224),
             "patch_size": config["patch_size"],
@@ -196,7 +199,7 @@ class DINOv3Model(nnx.Module):
             "rope_theta": config.get("rope_theta", 100.0),
             "layer_scale_init": config.get("layerscale_value", 1.0),
             "layernorm_epsilon": config.get("layer_norm_eps", 1e-5),
-            "hidden_act": config.get("hidden_act", "gelu"),
+            "act_fn": act_fn,
             "use_gated_mlp": config.get("use_gated_mlp", False),
             "use_patch_bias": config.get("use_patch_bias", True),
             "key_bias": config.get("key_bias", False),

--- a/src/jimm/models/dinov3/params.py
+++ b/src/jimm/models/dinov3/params.py
@@ -105,7 +105,7 @@ def _create_dinov3_config(model: "DINOv3Model") -> dict[str, Any]:
         "num_hidden_layers": enc.num_layers,
         "num_attention_heads": enc.num_heads,
         "intermediate_size": enc.mlp_dim,
-        "hidden_act": enc.hidden_act,
+        "hidden_act": model.hidden_act,
         "layer_norm_eps": enc.layernorm_epsilon,
         "rope_theta": enc.rope_theta,
         "image_size": enc.img_size,

--- a/src/jimm/models/dinov3/params.py
+++ b/src/jimm/models/dinov3/params.py
@@ -1,9 +1,11 @@
+import functools
 import json
 import os
 from collections.abc import Callable
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import rnglib
@@ -82,6 +84,15 @@ def _get_key_and_transform_mapping(use_gated_mlp: bool) -> dict[str, tuple[str, 
     return mapping
 
 
+def _act_fn_to_str(fn: Callable) -> str:
+    """Return the HuggingFace hidden_act name for a known activation function."""
+    if fn is jax.nn.silu:
+        return "silu"
+    if isinstance(fn, functools.partial) and fn.func is jax.nn.gelu:
+        return "gelu"
+    return "gelu"
+
+
 def _create_dinov3_config(model: "DINOv3Model") -> dict[str, Any]:
     """Create HuggingFace-compatible config dictionary for DINOv3.
 
@@ -105,7 +116,7 @@ def _create_dinov3_config(model: "DINOv3Model") -> dict[str, Any]:
         "num_hidden_layers": enc.num_layers,
         "num_attention_heads": enc.num_heads,
         "intermediate_size": enc.mlp_dim,
-        "hidden_act": model.hidden_act,
+        "hidden_act": _act_fn_to_str(model._act_fn),
         "layer_norm_eps": enc.layernorm_epsilon,
         "rope_theta": enc.rope_theta,
         "image_size": enc.img_size,

--- a/src/jimm/models/siglip/siglip_model.py
+++ b/src/jimm/models/siglip/siglip_model.py
@@ -7,10 +7,16 @@ from flax.nnx import rnglib
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, DTypeLike, Float, Int
 
+import functools
+
+import jax
+
 from jimm.common.sharding import ShardingSpec, named_sharding_like, reshard_like, sharding_of
 from jimm.common.transformer import Transformer
 from jimm.common.vit import VisionTransformerBase
 from jimm.models.siglip.sharding import SigLIPSharding
+
+_SIGLIP_ACT_FN = functools.partial(jax.nn.gelu, approximate=True)
 
 
 class SigLIPVisionModel(nnx.Module):
@@ -60,7 +66,7 @@ class SigLIPVisionModel(nnx.Module):
             mlp_dim=vision_hidden_size * 4,
             use_pre_norm=False,
             use_patch_bias=True,
-            use_quick_gelu=False,
+            act_fn=_SIGLIP_ACT_FN,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             pooling_type="MAP",
@@ -232,7 +238,7 @@ class SigLIPTextModel(nnx.Module):
             num_heads=num_text_heads,
             dropout_rate=0.0,
             layernorm_epsilon=1e-6,
-            use_quick_gelu=False,
+            act_fn=_SIGLIP_ACT_FN,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             rngs=rngs,

--- a/src/jimm/models/siglip/siglip_model.py
+++ b/src/jimm/models/siglip/siglip_model.py
@@ -1,15 +1,13 @@
+import functools
 from collections.abc import Callable
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 from flax.nnx import rnglib
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, DTypeLike, Float, Int
-
-import functools
-
-import jax
 
 from jimm.common.sharding import ShardingSpec, named_sharding_like, reshard_like, sharding_of
 from jimm.common.transformer import Transformer

--- a/src/jimm/models/vit/params.py
+++ b/src/jimm/models/vit/params.py
@@ -17,6 +17,7 @@ from jimm.common.loading_utils import (
     load_params_and_config,
 )
 from jimm.common.sharding import ShardingSpec
+from jimm.common.transformer import quickgelu
 from jimm.common.utils import convert_key_to_hf_format, filter_tensors
 from jimm.models.vit.sharding import ViTSharding
 
@@ -235,7 +236,7 @@ def load_from_pretrained(
         mlp_dim = config["intermediate_size"]
         patch_size = config["patch_size"]
         img_size = config["image_size"]
-        use_quick_gelu = config.get("hidden_act") == "quick_gelu"
+        act_fn = quickgelu if config.get("hidden_act") == "quick_gelu" else None
     elif not use_pytorch and os.path.isfile(model_name_or_path):
         hidden_size = params_fstate["vit.embeddings.cls_token"].shape[-1]
         num_classes = params_fstate["classifier.bias"].shape[0]
@@ -245,7 +246,7 @@ def load_from_pretrained(
         patch_size = params_fstate["vit.embeddings.patch_embeddings.projection.weight"].shape[2]
         n_patches = params_fstate["vit.embeddings.position_embeddings"].shape[1] - 1
         img_size = int(n_patches**0.5) * patch_size
-        use_quick_gelu = False
+        act_fn = None
     else:
         raise ValueError(f"Could not load or infer configuration for {model_name_or_path}")
 
@@ -257,7 +258,7 @@ def load_from_pretrained(
         num_heads=num_heads,
         mlp_dim=mlp_dim,
         hidden_size=hidden_size,
-        use_quick_gelu=use_quick_gelu,
+        act_fn=act_fn,
         sharding=sharding,
         dtype=dtype,
         param_dtype=param_dtype,

--- a/src/jimm/models/vit/vit_model.py
+++ b/src/jimm/models/vit/vit_model.py
@@ -9,6 +9,7 @@ from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
 from jimm.common.sharding import ShardingSpec, named_sharding_like, sharding_of
+from jimm.common.transformer import quickgelu
 from jimm.common.vit import VisionTransformerBase
 from jimm.models.vit.sharding import ViTSharding
 
@@ -31,7 +32,7 @@ class VisionTransformer(nnx.Module):
         mlp_dim: int = 3072,
         hidden_size: int = 768,
         dropout_rate: float = 0.1,
-        use_quick_gelu: bool = False,
+        act_fn: Callable | None = None,
         use_gradient_checkpointing: bool = False,
         attention_fn: Callable[..., Any] | None = None,
         do_classification: bool = True,
@@ -52,7 +53,7 @@ class VisionTransformer(nnx.Module):
             mlp_dim (int, optional): Size of the MLP dimension. Defaults to 3072.
             hidden_size (int, optional): Size of the hidden dimension. Defaults to 768.
             dropout_rate (float, optional): Dropout rate. Defaults to 0.1.
-            use_quick_gelu (bool, optional): Whether to use quickgelu instead of gelu. Defaults to False.
+            act_fn (Callable | None, optional): MLP activation function. When None, defaults to exact GELU. Pass ``quickgelu`` for OpenCLIP-style ViTs. Defaults to None.
             use_gradient_checkpointing (bool, optional): Whether to use gradient checkpointing. Defaults to False.
             attention_fn (Callable[..., Any] | None, optional): Custom attention function (e.g. jimm.tokamax_attention). Defaults to None.
             do_classification (bool, optional): Whether to include the final classification head. Defaults to True.
@@ -74,7 +75,7 @@ class VisionTransformer(nnx.Module):
             num_heads=num_heads,
             mlp_dim=mlp_dim,
             dropout_rate=dropout_rate,
-            use_quick_gelu=use_quick_gelu,
+            act_fn=act_fn,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             use_pre_norm=False,
@@ -179,7 +180,7 @@ class VisionTransformer(nnx.Module):
         if rngs is None:
             rngs = nnx.Rngs(0)
         num_classes = len(config["id2label"]) if "id2label" in config else config.get("num_labels", 1000)
-        use_quick_gelu = config.get("hidden_act") == "quick_gelu"
+        act_fn = quickgelu if config.get("hidden_act") == "quick_gelu" else None
 
         return cls(
             num_classes=num_classes,
@@ -189,7 +190,7 @@ class VisionTransformer(nnx.Module):
             num_heads=config["num_attention_heads"],
             mlp_dim=config["intermediate_size"],
             hidden_size=config["hidden_size"],
-            use_quick_gelu=use_quick_gelu,
+            act_fn=act_fn,
             use_gradient_checkpointing=use_gradient_checkpointing,
             attention_fn=attention_fn,
             dtype=dtype,

--- a/tests/test_aimv2.py
+++ b/tests/test_aimv2.py
@@ -48,7 +48,7 @@ def test_aimv2_from_config(config: dict) -> None:
     model = AIMv2Model.from_config(config, rngs=nnx.Rngs(0))
     model.eval()
     x = jnp.ones((1, _CONFIG_SMALL["image_size"], _CONFIG_SMALL["image_size"], 3))
-    out = model(x)
+    out = _forward(model, x)
     assert out.shape == (1, _SMALL_N_PATCHES, _CONFIG_SMALL["hidden_size"])
 
 
@@ -61,8 +61,8 @@ def test_aimv2_gradient_checkpointing(config: dict) -> None:
     nnx.update(model_ckpt, nnx.state(model))
     model.eval()
     model_ckpt.eval()
-    out = model(x)
-    out_ckpt = model_ckpt(x)
+    out = _forward(model, x)
+    out_ckpt = _forward(model_ckpt, x)
     assert out.shape == out_ckpt.shape
     assert jnp.allclose(out, out_ckpt, atol=1e-5), f"Checkpointed output differs by up to {jnp.abs(out - out_ckpt).max()}"
 
@@ -87,7 +87,7 @@ def test_aimv2_inference() -> None:
 
     max_diff = jnp.abs(jimm_out - hf_out).max()
     print(f"[{HF_MODEL_NAME}] Max absolute difference: {max_diff}")
-    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=5e-3)
+    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=5e-3), f"Max absolute difference: {max_diff}"
 
 
 @pytest.mark.slow
@@ -149,7 +149,7 @@ def test_aimv2_lit_inference() -> None:
 
     max_diff = jnp.abs(jimm_out - hf_out).max()
     print(f"[{HF_LIT_MODEL_NAME}] Max absolute difference: {max_diff}")
-    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=5e-3)
+    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=5e-3), f"Max absolute difference: {max_diff}"
 
 
 @pytest.mark.slow

--- a/tests/test_dinov2.py
+++ b/tests/test_dinov2.py
@@ -21,6 +21,7 @@ _NATIVE_IMG_SIZE = 518
 
 devices = mesh_utils.create_device_mesh((jax.device_count(), 1))
 mesh = Mesh(devices, ("data", "fsdp"))
+jax.set_mesh(mesh)
 
 
 @nnx.jit
@@ -28,15 +29,14 @@ def _forward(model: DINOv2Model, x: Float[Array, "batch height width channels"])
     return model(x)
 
 
-def _run_inference_test(hf_model_name: str, atol: float = 0.05) -> None:
+def _run_inference_test(hf_model_name: str, atol: float = 1e-4) -> None:
     """Load model and compare CLS-token output with HuggingFace Dinov2Model at native 518x518.
 
     Args:
         hf_model_name (str): HuggingFace model ID (e.g. "facebook/dinov2-small").
-        atol (float, optional): Absolute tolerance for numerical comparison. Defaults to 0.05.
+        atol (float, optional): Absolute tolerance for numerical comparison. Defaults to 1e-4.
     """
-    with mesh:
-        model = DINOv2Model.from_pretrained(hf_model_name, rngs=nnx.Rngs(0))
+    model = DINOv2Model.from_pretrained(hf_model_name, rngs=nnx.Rngs(0))
     model.eval()
 
     hf_model = HFDinov2Model.from_pretrained(hf_model_name)
@@ -53,7 +53,7 @@ def _run_inference_test(hf_model_name: str, atol: float = 0.05) -> None:
 
     max_diff = jnp.abs(jimm_out - hf_out).max()
     print(f"[{hf_model_name}] Max absolute difference: {max_diff}")
-    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=atol)
+    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=atol), f"Max absolute difference: {max_diff}"
 
 
 def _run_from_config_test(hf_model_name: str) -> None:
@@ -63,11 +63,10 @@ def _run_from_config_test(hf_model_name: str) -> None:
         hf_model_name (str): HuggingFace model ID (e.g. "facebook/dinov2-small").
     """
     config = AutoConfig.from_pretrained(hf_model_name).to_dict()
-    with mesh:
-        model = DINOv2Model.from_config(config, rngs=nnx.Rngs(0))
+    model = DINOv2Model.from_config(config, rngs=nnx.Rngs(0))
     model.eval()
     x = jnp.ones((1, config["image_size"], config["image_size"], 3))
-    out = model(x)
+    out = _forward(model, x)
     assert out.shape == (1, config["hidden_size"])
 
 
@@ -92,13 +91,10 @@ def test_dinov2_small_from_config() -> None:
 def test_dinov2_base_inference() -> None:
     """Compare dinov2-base CLS-token output with HuggingFace reference at native 518x518.
 
-    dinov2-base uses hidden_size=768, num_heads=12, mlp_dim=3072 vs small's 384/6/1536.
-    Larger matrix dimensions accumulate slightly more float32 error, so atol=0.06 is used.
-
     Returns:
         None
     """
-    _run_inference_test(HF_MODEL_NAME_BASE, atol=0.06)
+    _run_inference_test(HF_MODEL_NAME_BASE)
 
 
 def test_dinov2_base_from_config() -> None:
@@ -116,8 +112,7 @@ def test_dinov2_small_save_pretrained_roundtrip() -> None:
     Returns:
         None
     """
-    with mesh:
-        model = DINOv2Model.from_pretrained(HF_MODEL_NAME_SMALL, rngs=nnx.Rngs(0))
+    model = DINOv2Model.from_pretrained(HF_MODEL_NAME_SMALL, rngs=nnx.Rngs(0))
     model.eval()
 
     rng = np.random.default_rng(42)
@@ -138,8 +133,7 @@ def test_dinov2_small_save_pretrained_roundtrip() -> None:
         assert np.allclose(saved["encoder.layer.0.mlp.fc1.weight"], hf_weights["encoder.layer.0.mlp.fc1.weight"], atol=1e-6)
         assert np.allclose(saved["encoder.layer.0.attention.attention.query.weight"], hf_weights["encoder.layer.0.attention.attention.query.weight"], atol=1e-6)
 
-        with mesh:
-            reloaded = DINOv2Model.from_pretrained(tmpdir, rngs=nnx.Rngs(0))
+        reloaded = DINOv2Model.from_pretrained(tmpdir, rngs=nnx.Rngs(0))
         reloaded.eval()
         reloaded_out = _forward(reloaded, x)
 

--- a/tests/test_dinov3.py
+++ b/tests/test_dinov3.py
@@ -37,12 +37,12 @@ def _forward(model: DINOv3Model, x: Float[Array, "batch height width channels"])
     return model(x)
 
 
-def _run_inference_test(hf_model_name: str, atol: float = 0.05) -> None:
+def _run_inference_test(hf_model_name: str, atol: float = 1e-4) -> None:
     """Load model and compare CLS-token output with HuggingFace reference at native 224x224.
 
     Args:
         hf_model_name (str): HuggingFace model ID (e.g. "facebook/dinov3-vits16-pretrain-lvd1689m").
-        atol (float, optional): Absolute tolerance for numerical comparison. Defaults to 0.05.
+        atol (float, optional): Absolute tolerance for numerical comparison. Defaults to 1e-4.
     """
     model = DINOv3Model.from_pretrained(hf_model_name, rngs=nnx.Rngs(0))
     model.eval()
@@ -61,7 +61,7 @@ def _run_inference_test(hf_model_name: str, atol: float = 0.05) -> None:
 
     max_diff = jnp.abs(jimm_out - hf_out).max()
     print(f"[{hf_model_name}] Max absolute difference: {max_diff}")
-    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=atol)
+    assert jnp.allclose(jimm_out, jnp.array(hf_out), atol=atol), f"Max absolute difference: {max_diff}"
 
 
 def test_dinov3_small_from_config() -> None:
@@ -73,7 +73,7 @@ def test_dinov3_small_from_config() -> None:
     model = DINOv3Model.from_config(_CONFIG_SMALL, rngs=nnx.Rngs(0))
     model.eval()
     x = jnp.ones((1, _CONFIG_SMALL["image_size"], _CONFIG_SMALL["image_size"], 3))
-    out = model(x)
+    out = _forward(model, x)
     assert out.shape == (1, _CONFIG_SMALL["hidden_size"])
 
 
@@ -86,7 +86,7 @@ def test_dinov3_gated_mlp_from_config() -> None:
     model = DINOv3Model.from_config(_CONFIG_SMALL_GATED, rngs=nnx.Rngs(0))
     model.eval()
     x = jnp.ones((1, _CONFIG_SMALL_GATED["image_size"], _CONFIG_SMALL_GATED["image_size"], 3))
-    out = model(x)
+    out = _forward(model, x)
     assert out.shape == (1, _CONFIG_SMALL_GATED["hidden_size"])
 
 
@@ -99,7 +99,7 @@ def test_dinov3_variable_image_size() -> None:
     model = DINOv3Model.from_config(_CONFIG_SMALL, rngs=nnx.Rngs(0))
     model.eval()
     for h, w in [(192, 256), (320, 320), (224, 224)]:
-        out = model(jnp.ones((1, h, w, 3)))
+        out = _forward(model, jnp.ones((1, h, w, 3)))
         assert out.shape == (1, _CONFIG_SMALL["hidden_size"])
 
 
@@ -115,8 +115,8 @@ def test_dinov3_gradient_checkpointing() -> None:
     nnx.update(model_ckpt, nnx.state(model))
     model.eval()
     model_ckpt.eval()
-    out = model(x)
-    out_ckpt = model_ckpt(x)
+    out = _forward(model, x)
+    out_ckpt = _forward(model_ckpt, x)
     assert out.shape == out_ckpt.shape
     assert jnp.allclose(out, out_ckpt, atol=1e-5), f"Checkpointed output differs by up to {jnp.abs(out - out_ckpt).max()}"
 

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -49,9 +49,7 @@ def test_vision_transformer_inference() -> None:
     Returns:
         None
     """
-    global mesh
-    with mesh:
-        model = create_model()
+    model = create_model()
     image = Image.open("images/test_image.jpg")
     processor = ViTImageProcessor.from_pretrained(HF_MODEL_NAME)
     inputs = processor(images=image, return_tensors="pt")
@@ -64,8 +62,9 @@ def test_vision_transformer_inference() -> None:
     model.eval()
     x_eval: Float[Array, "batch height width channels"] = jnp.transpose(inputs["pixel_values"].detach().cpu().numpy(), axes=(0, 2, 3, 1))
     logits_flax = forward(model, x_eval)
-    print(f"Max absolute difference: {jnp.abs(logits_flax - logits_ref).max()}")
-    assert jnp.allclose(logits_flax, logits_ref, atol=0.05)
+    max_diff = jnp.abs(logits_flax - logits_ref).max()
+    print(f"Max absolute difference: {max_diff}")
+    assert jnp.allclose(logits_flax, logits_ref, atol=1e-4), f"Max absolute difference: {max_diff}"
 
 
 def test_vision_transformer_from_config() -> None:
@@ -76,8 +75,9 @@ def test_vision_transformer_from_config() -> None:
     """
     config = AutoConfig.from_pretrained(HF_MODEL_NAME).to_dict()
     model = VisionTransformer.from_config(config, rngs=nnx.Rngs(0))
+    model.eval()
     x = jnp.ones((1, config["image_size"], config["image_size"], 3))
-    output = model(x)
+    output = forward(model, x)
     num_classes = len(config["id2label"]) if "id2label" in config else config.get("num_labels", 1000)
     assert output.shape == (1, num_classes)
 


### PR DESCRIPTION
This pull request refactors how activation functions are handled in the Vision Transformer (ViT) and Transformer modules. Instead of using multiple boolean flags and string identifiers for activation selection (like `use_quick_gelu` and `hidden_act`), the code now consistently accepts an `act_fn` callable throughout the model stack. This makes it easier and more flexible to specify custom activation functions, improves code clarity, and reduces the risk of misconfiguration.

The most important changes are:

**API and Configuration Simplification:**
* Replaced the `use_quick_gelu` boolean and `hidden_act` string parameters with a single `act_fn` callable parameter in `Transformer`, `VisionTransformerBase`, and related model classes. This allows users to directly pass any activation function (e.g., `quickgelu`, `jax.nn.silu`, or partials of `jax.nn.gelu`). [[1]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L120-L125) [[2]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L145-L151) [[3]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L167-R174) [[4]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L438-L443) [[5]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L464-L470) [[6]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcR32) [[7]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcR46-R47) [[8]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL169-R175) [[9]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL206-R213) [[10]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL327-L332) [[11]](diffhunk://#diff-bd74829e9ed8257db870495547b8ff33cca075f07429cc3f0298a0fee622e5a3L67-R67) [[12]](diffhunk://#diff-bd74829e9ed8257db870495547b8ff33cca075f07429cc3f0298a0fee622e5a3L259-R260) [[13]](diffhunk://#diff-ee7f56324a8739979245fd4fad07691da3f8bd1a5a28becf366c74fd7a66b54eL74-R75)
* Updated all downstream model classes (`clip_model.py`, `aimv2_model.py`, `dinov2_model.py`, `dinov3_model.py`) to use the new `act_fn` parameter and removed legacy activation selection code. [[1]](diffhunk://#diff-bd74829e9ed8257db870495547b8ff33cca075f07429cc3f0298a0fee622e5a3L67-R67) [[2]](diffhunk://#diff-bd74829e9ed8257db870495547b8ff33cca075f07429cc3f0298a0fee622e5a3L259-R260) [[3]](diffhunk://#diff-ee7f56324a8739979245fd4fad07691da3f8bd1a5a28becf366c74fd7a66b54eL74-R75) [[4]](diffhunk://#diff-ee7f56324a8739979245fd4fad07691da3f8bd1a5a28becf366c74fd7a66b54eL83) [[5]](diffhunk://#diff-2bb38eb18c39b054656e4b9391f285b6d2b4836733a409f955f6beffc0395e71L75) [[6]](diffhunk://#diff-7346697beae7cee5daf818c390df2f548c7e4ef587524e54930dbdb0f4e1d335R86-R90)

**Documentation and Type Annotations:**
* Updated docstrings and type annotations to reflect the new `act_fn` parameter, including guidance on what to pass for different model variants (e.g., CLIP, SigLIP, SwiGLU). [[1]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L145-L151) [[2]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L464-L470) [[3]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcR46-R47) [[4]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL206-R213)

**Implementation Details:**
* Centralized activation function selection logic, defaulting to exact GELU if `act_fn` is not provided, and removed checks for string-based activations. [[1]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L167-R174) [[2]](diffhunk://#diff-f6f456c9481f42fde5b49e9da4ddadd213c896c6c32553c59942646df6f8cc06L251-R249) [[3]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcR105-R106) [[4]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL117-R123)
* In DINOv3, added a mapping from string names to activation callables and validation for the `hidden_act` argument, improving error messages and flexibility. [[1]](diffhunk://#diff-7346697beae7cee5daf818c390df2f548c7e4ef587524e54930dbdb0f4e1d335R16-R20) [[2]](diffhunk://#diff-7346697beae7cee5daf818c390df2f548c7e4ef587524e54930dbdb0f4e1d335R86-R90)

**Code Cleanup:**
* Removed unused parameters and code paths related to the old activation selection mechanism, reducing complexity and potential for bugs. (F7b6ba6fL176R182, [[1]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL219) [[2]](diffhunk://#diff-6745725737108a45bb8709f4dab23464096c252710d029639a24cc10781179fcL347) [[3]](diffhunk://#diff-ee7f56324a8739979245fd4fad07691da3f8bd1a5a28becf366c74fd7a66b54eL83)

Overall, this change unifies and modernizes activation function configuration, making the codebase more robust and easier to extend.